### PR TITLE
Add controllable player character

### DIFF
--- a/scenes/Player.tscn
+++ b/scenes/Player.tscn
@@ -1,0 +1,5 @@
+[gd_scene load_steps=2 format=2]
+[ext_resource path="res://scripts/Player.gd" type="Script" id=1]
+
+[node name="Player" type="KinematicBody2D"]
+script = ExtResource( 1 )

--- a/scenes/WorldMap.tscn
+++ b/scenes/WorldMap.tscn
@@ -1,7 +1,10 @@
-[gd_scene load_steps=2 format=2]
-
+[gd_scene load_steps=3 format=2]
 [ext_resource path="res://scripts/WorldMap.gd" type="Script" id=1]
+[ext_resource path="res://scenes/Player.tscn" type="PackedScene" id=2]
 
 [node name="WorldMap" type="TileMap"]
 script = ExtResource( 1 )
 cell_size = Vector2(16, 16)
+
+[node name="Player" parent="." instance=ExtResource( 2 )]
+position = Vector2(64, 64)

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -1,0 +1,31 @@
+extends KinematicBody2D
+
+export var speed := 100
+
+func _ready():
+    var sprite = Sprite.new()
+    sprite.texture = _create_texture(Color(1, 0, 0))
+    sprite.centered = true
+    add_child(sprite)
+    var collision = CollisionShape2D.new()
+    var shape = RectangleShape2D.new()
+    shape.extents = Vector2(8, 8)
+    collision.shape = shape
+    add_child(collision)
+
+func _physics_process(delta):
+    var input_vector = Vector2(
+        Input.get_action_strength("ui_right") - Input.get_action_strength("ui_left"),
+        Input.get_action_strength("ui_down") - Input.get_action_strength("ui_up")
+    )
+    if input_vector.length() > 0:
+        input_vector = input_vector.normalized()
+    move_and_slide(input_vector * speed)
+
+func _create_texture(color: Color):
+    var img = Image.new()
+    img.create(16, 16, false, Image.FORMAT_RGBA8)
+    img.fill(color)
+    var tex = ImageTexture.new()
+    tex.create_from_image(img)
+    return tex


### PR DESCRIPTION
## Summary
- Spawn a player character inside the world map
- Script a basic player for directional movement and sprite generation

## Testing
- `godot3 --headless --path . --quit` *(fails: X11 Display is not available)*

------
https://chatgpt.com/codex/tasks/task_e_68980c60dc6c8331957ee44b254d79b9