### PR TITLE
Add pickable equipable items

### DIFF
--- a/scenes/Item.tscn
+++ b/scenes/Item.tscn
@@ -1,0 +1,5 @@
+[gd_scene load_steps=2 format=2]
+[ext_resource path="res://scripts/Item.gd" type="Script" id=1]
+
+[node name="Item" type="Area2D"]
+script = ExtResource( 1 )

--- a/scripts/Item.gd
+++ b/scripts/Item.gd
@@ -1,0 +1,36 @@
+extends Area2D
+
+export(String) var slot := "W"
+export(Color) var color := Color(1, 1, 1)
+
+func _ready():
+    var sprite = Sprite.new()
+    sprite.texture = _create_texture(color)
+    sprite.centered = true
+    add_child(sprite)
+    var label = Label.new()
+    label.text = slot
+    label.align = Label.ALIGN_CENTER
+    label.valign = Label.VALIGN_CENTER
+    label.rect_position = Vector2(-8, -8)
+    label.rect_size = Vector2(16, 16)
+    add_child(label)
+    var collision = CollisionShape2D.new()
+    var shape = RectangleShape2D.new()
+    shape.extents = Vector2(8, 8)
+    collision.shape = shape
+    add_child(collision)
+    connect("body_entered", self, "_on_body_entered")
+
+func _on_body_entered(body):
+    if body.has_method("equip_item"):
+        body.equip_item(self)
+        queue_free()
+
+func _create_texture(color: Color):
+    var img = Image.new()
+    img.create(16, 16, false, Image.FORMAT_RGBA8)
+    img.fill(color)
+    var tex = ImageTexture.new()
+    tex.create_from_image(img)
+    return tex

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -2,16 +2,34 @@ extends KinematicBody2D
 
 export var speed := 100
 
+const SLOT_OFFSETS = {
+    "H": Vector2(0, -16),
+    "B": Vector2(0, 0),
+    "L": Vector2(0, 16),
+    "A": Vector2(-16, 0),
+    "W": Vector2(16, 0)
+}
+
+var equipment := {}
+
 func _ready():
-    var sprite = Sprite.new()
-    sprite.texture = _create_texture(Color(1, 0, 0))
-    sprite.centered = true
-    add_child(sprite)
+    for slot in SLOT_OFFSETS.keys():
+        var sprite = Sprite.new()
+        sprite.texture = _create_texture(Color(0.5, 0.5, 0.5))
+        sprite.position = SLOT_OFFSETS[slot]
+        sprite.centered = true
+        add_child(sprite)
+        equipment[slot] = sprite
     var collision = CollisionShape2D.new()
     var shape = RectangleShape2D.new()
     shape.extents = Vector2(8, 8)
     collision.shape = shape
     add_child(collision)
+
+func equip_item(item):
+    var slot = item.slot
+    if equipment.has(slot):
+        equipment[slot].texture = _create_texture(item.color)
 
 func _physics_process(delta):
     var input_vector = Vector2(

--- a/scripts/WorldMap.gd
+++ b/scripts/WorldMap.gd
@@ -4,10 +4,21 @@ const MAP_WIDTH = 128
 const MAP_HEIGHT = 128
 const TILE_SIZE = 16
 
+const ITEM_SCENE = preload("res://scenes/Item.tscn")
+const SLOTS = ["H", "B", "L", "A", "W"]
+const QUALITY_COLORS = [
+    Color(0.5, 0.5, 0.5), # Grey
+    Color(0, 1, 0),       # Green
+    Color(0, 0, 1),       # Blue
+    Color(0.5, 0, 0.5),   # Purple
+    Color(1, 0.84, 0)     # Gold
+]
+
 func _ready():
     randomize()
     tile_set = _create_tile_set()
     _generate_map()
+    _spawn_items()
 
 func _create_tile_set():
     var ts = TileSet.new()
@@ -43,3 +54,14 @@ func _generate_map():
             if n <= 0.0:
                 tile_id = 1
             set_cellv(Vector2(x, y), tile_id)
+
+func _spawn_items():
+    for slot in SLOTS:
+        var item = ITEM_SCENE.instance()
+        item.slot = slot
+        item.color = QUALITY_COLORS[randi() % QUALITY_COLORS.size()]
+        item.position = Vector2(
+            randi() % (MAP_WIDTH * TILE_SIZE),
+            randi() % (MAP_HEIGHT * TILE_SIZE)
+        )
+        add_child(item)


### PR DESCRIPTION
## Summary
- introduce `Item` scene that spawns a pickable gear block and equips players on contact
- extend `Player` to track five equipment slots and recolor them when picking up items
- spawn randomized items across the map with colors representing gear quality

## Testing
- `godot3-server --check project.godot`

------
https://chatgpt.com/codex/tasks/task_e_689881538ea48331b7f2b31aa778d56a